### PR TITLE
fix for compatibiliy with protected_attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # attr_encrypted #
 
+## 4.0.0 ##
+
+* Changed: Updated the ActiveAdmin adapter so `assign_attributes` is called with 1 attribute sinsteda of 2 to avoid this issue when also using the `protected_attributes` gem:
+
+```
+Assignment.new(:claim_number => 'abc')
+ArgumentError: wrong number of arguments (given 2, expected 1)
+from ~/.rvm/gems/ruby-2.3.8@snapsheet/gems/activerecord-4.0.13/lib/active_record/attribute_assignment.rb:14:in `assign_attributes'
+```
+
+**Snapsheet Fork**
+
 ## 3.1.0 ##
 * Added: Abitilty to encrypt empty values. (@tamird)
 * Added: MIT license

--- a/lib/attr_encrypted/adapters/active_record.rb
+++ b/lib/attr_encrypted/adapters/active_record.rb
@@ -27,8 +27,8 @@ if defined?(ActiveRecord::Base)
             def perform_attribute_assignment(method, new_attributes, *args)
               return if new_attributes.blank?
 
-              send method, new_attributes.reject { |k, _|  self.class.encrypted_attributes.key?(k.to_sym) }, *args
-              send method, new_attributes.reject { |k, _| !self.class.encrypted_attributes.key?(k.to_sym) }, *args
+              send method, new_attributes.reject { |k, _|  self.class.encrypted_attributes.key?(k.to_sym) } #, *args
+              send method, new_attributes.reject { |k, _| !self.class.encrypted_attributes.key?(k.to_sym) } #, *args
             end
             private :perform_attribute_assignment
 

--- a/lib/attr_encrypted/version.rb
+++ b/lib/attr_encrypted/version.rb
@@ -3,8 +3,8 @@
 module AttrEncrypted
   # Contains information about this gem's version
   module Version
-    MAJOR = 3
-    MINOR = 1
+    MAJOR = 4
+    MINOR = 0
     PATCH = 0
 
     # Returns a version string by joining <tt>MAJOR</tt>, <tt>MINOR</tt>, and <tt>PATCH</tt> with <tt>'.'</tt>


### PR DESCRIPTION
Adding protected_parameters gem ([PR](https://github.com/bodyshopbidsdotcom/snapsheet/pull/18709))) for rails 4 was resulting in [this error](https://github.com/rails/protected_attributes/issues/53#issuecomment-710263023) coming from attr_encrypted gem and is resolved with this change.

## Testing

Check instruction on [this PR](https://github.com/bodyshopbidsdotcom/snapsheet/pull/18709)